### PR TITLE
#22 thread user text color

### DIFF
--- a/src/lib/components/post.svelte
+++ b/src/lib/components/post.svelte
@@ -18,7 +18,7 @@
 
 <article>
   <div class="flex">
-    <h3 style="color: #{event.pubkey.slice(0, 6)};">
+    <h3 style="border-left: 4px solid #{event.pubkey.slice(0, 6)}; text-indent: 0.5rem;">
       んちゃんねるから{event.pubkey.slice(0, 6)}がお送りします
     </h3>
     <time data-time={parseCreated(event.created_at)}
@@ -55,6 +55,9 @@
 </article>
 
 <style>
+  h3 {
+    color: #0B8E14;
+  }
   .flex {
     gap: 4px 8px;
     margin-bottom: 8px;


### PR DESCRIPTION
- スレッドのテキストカラーを修正しました

<img width="681" alt="Screenshot 2024-08-16 at 19 51 32" src="https://github.com/user-attachments/assets/cc880ff9-a525-4a8b-ac72-5682a767deea">

誰が発言したかより、内容に目がいくようなカラーになっています